### PR TITLE
Fix automatic creation of ~/.kanban.conf causing bash syntax errors

### DIFF
--- a/kanban
+++ b/kanban
@@ -75,7 +75,7 @@ config_example="# kanban config file
 statuses=('BACKLOG' 'HOLD' 'DOING' 'CODE' 'DONE') 
 
 # maximum amount of todos within status (triggers warning when exceeds)
-declare -a maximum_todo
+declare -A maximum_todo
 maximum_todo['HOLD']=5
 maximum_todo['DOING']=4
 maximum_todo['CODE']=3


### PR DESCRIPTION
Preconditons:

* GNU bash, version 4.4.12
* no prior kanban.bash installation, no existing ~/.kanban.conf

Steps:

1. git clone https://github.com/coderofsalvation/kanban.bash
2. copy `kanban` to a bin or anywhere in $PATH so it can run, such as /usr/local/bin
3. open a new terminal
4. run `kanban`

Result:

* there is an error, to stderr:

    /home/youruser/.kanban.conf: line 8: 'HOLD': syntax error: operand expected (error token is "'HOLD'")

* usage info appears after

Expected:

* usage info appears without any errors

Fix

* in `kanban`, find `declare -a maximum_todo` and replace to `declare -A maximum_todo`
* ensure ~/.kanban.conf is deleted before you re-run fixed `kanban`, so it will generate a new one

Background

* seems recent commit eba8fbc made changes:

    - declare -A maximum_todo
    + declare -a maximum_todo

* but kanban config needs to use: `maximum_todo['HOLD']=5`
* it is an associative array
* man bash: `Associative arrays are created using declare -A name`
* so the fix is just to change lowercase `-a` to uppercase `-A` to declare an associative array in order to do something like `maximum_todo['HOLD']=5`