### PR TITLE
Set .kanban.conf to use Bash 4 declare -A. Add comments to help Bash …

### DIFF
--- a/kanban
+++ b/kanban
@@ -75,7 +75,9 @@ config_example="# kanban config file
 statuses=('BACKLOG' 'HOLD' 'DOING' 'CODE' 'DONE') 
 
 # maximum amount of todos within status (triggers warning when exceeds)
-declare -a maximum_todo
+# NOTE: if using bash version < 4 and see error "-A: invalid option",
+# a workaround is to edit the line below to "declare -a maximum_todo"
+declare -A maximum_todo
 maximum_todo['HOLD']=5
 maximum_todo['DOING']=4
 maximum_todo['CODE']=3


### PR DESCRIPTION
`~/.kanban.conf` to use Bash 4 declare -A. Add comments to help Bash earlier than 4 users

This is to fix #15