### PR TITLE
Use env to find bash which isn't always in /bin/bash

### DIFF
--- a/kanban
+++ b/kanban
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # commandline asciii kanban board for minimalist productivity bash hackers (csv-based)
 #


### PR DESCRIPTION
On FreeBSD & OpenBSD, `bash` installs in /usr/local/bin/bash so the shebang line doesn't find a `/bin/bash`. By using `env` to find `bash`, it now works on both Linux and the BSDs.