### PR TITLE
Portably fix #15

### DIFF
--- a/kanban
+++ b/kanban
@@ -69,16 +69,17 @@ if [[ ! -n "${KANBANFILE}" ]]; then
 fi
 [[ ! -f "${KANBANFILE}" ]] && echo '"status","tag","description","history","date"' > "${KANBANFILE}"
 
-config_example="# kanban config file
-
 # kanban config file
+config_example="
+# kanban config file
+
 statuses=('BACKLOG' 'HOLD' 'DOING' 'CODE' 'DONE') 
 
 # maximum amount of todos within status (triggers warning when exceeds)
 declare -a maximum_todo
-maximum_todo['HOLD']=5
-maximum_todo['DOING']=4
-maximum_todo['CODE']=3
+maximum_todo[\"HOLD\"]=5
+maximum_todo[\"DOING\"]=4
+maximum_todo[\"CODE\"]=3
 "
 
 # usage: fb put <x> <y> <string>

--- a/kanban
+++ b/kanban
@@ -70,6 +70,8 @@ fi
 [[ ! -f "${KANBANFILE}" ]] && echo '"status","tag","description","history","date"' > "${KANBANFILE}"
 
 # kanban config file
+# Please note that the escaped quotes
+# will NOT be escaped in the actual file. This is intentional.
 config_example="
 # kanban config file
 


### PR DESCRIPTION
Portably fix #15 

Change originally proposed by https://github.com/coderofsalvation/kanban.bash/issues/15#issuecomment-441357403

From the same comment:
> Note that the double quotes must be escaped in kanban executable, in the resulting kanban.conf they are unescaped.