### PR TITLE
Suppress tput warning for missing capabilities

### DIFF
--- a/kanban
+++ b/kanban
@@ -190,7 +190,7 @@ stats(){
 }
 
 _init(){                          
-  trap "[[ ! -n \$NOCOLOR ]] && tput cnorm -- normal; " 0 1 5    # reset terminal colors to normal
+  trap "[[ ! -n \$NOCOLOR ]] && tput cnorm -- normal 2>/dev/null; " 0 1 5    # reset terminal colors to normal
   (( $X > $XSMALL )) && unset SMALLSCREEN
   [[ -n $NOCOLOR ]] && { COL1="";COL0="";COL2=""; COL3=""; }
 }


### PR DESCRIPTION
Some Linux terminals like xterm, xterm-256 do not have the `normal` capability (e.g. see `infocmp xterm`).
This diff will suppress the stderr output on each `kanban` invocation.

---

Note: Depending on the terminal capabilities on other systems, `tput init` could be a more portable way to reset the terminal.
