### PR TITLE
Change termcap to sgr0 for resetting terminal colors - fixes tput warning

### DIFF
--- a/kanban
+++ b/kanban
@@ -190,7 +190,7 @@ stats(){
 }
 
 _init(){                          
-  trap "[[ ! -n \$NOCOLOR ]] && tput cnorm -- normal; " 0 1 5    # reset terminal colors to normal
+  trap "[[ -z \$NOCOLOR ]] && tput sgr0" 0 1 5    # reset terminal colors to normal
   (( $X > $XSMALL )) && unset SMALLSCREEN
   [[ -n $NOCOLOR ]] && { COL1="";COL0="";COL2=""; COL3=""; }
 }


### PR DESCRIPTION
I got this warning from tput everytime I run `kanban`

    tput: unknown terminfo capability 'normal'

The tput command within the `trap` has a weird syntax which is not correct (at least as I am aware of).
I could not find any reference where, after the terminal capability, two dashes signal the end of cli options, followed by "normal".
Could this be a copy & paste error?

Anyhow, my fix seems to work fine. 
Also, I changed the capability from `cnorm` to `sgr0` which seems more appropriate for resetting the terminal colors.

