### PR TITLE
sed (GNU sed) 4.9 on archlinux,termux not support sed -i '' '...'

### DIFF
--- a/kanban
+++ b/kanban
@@ -309,7 +309,7 @@ update_item_status(){
     newitem="${newitem/$status/$2}"
     newitem="${newitem/$flags/$newflags}"
     newitem="${newitem/$dates/$newdates}"
-    sed -i '' "s|$item|$newitem|g" "$KANBANFILE" 
+    sed "s|$item|$newitem|g" "$KANBANFILE" > $TMP.update.tmp && mv $TMP.update.tmp "$KANBANFILE"
     echo "$status -> $2"
   fi
 }
@@ -327,7 +327,7 @@ update_item(){
 #
 '"$item" > $TMP.update
   ${EDITOR} $TMP.update
-  sed -i '' "s|$item|$(cat $TMP.update | tail -n1)|g" "$KANBANFILE" 
+  sed "s|$item|$(cat $TMP.update | tail -n1)|g" "$KANBANFILE" > $TMP.update.tmp && mv $TMP.update.tmp "$KANBANFILE"
   echo "updated item $1"
 }
 


### PR DESCRIPTION
executing next command on archilnux machine or on termux environment:

```
KANBANFILE="test/test.csv" ./kanban 1 DOING
```

sed command raise this error and KANBANFILE is not updated

```
sed: can't read s|"HOLD","project10","fix item 1","H","2024-10-17@10:11"|"DOING","project10","fix item 1","HD","2024-10-17@10:11 2024-10-29@01:40"|g: No such file or directory
HOLD -> DOING
```

updating item with editor raise same behaviour.

Prevent use of sed -i '' fix the issue.

i am using:

```
Linux a 6.11.5-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 22 Oct 2024 18:31:38 +0000 x86_64 GNU/Linux
```

and this version of sed command:

```
sed (GNU sed) 4.9
```


